### PR TITLE
[Fix] Updated auth sdk version with client id update to docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcana/auth-wagmi",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Wagmi connector for Arcana Auth",
   "author": "makylfang",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "@arcana/auth": "^1.0.0",
+    "@arcana/auth": "^1.0.2",
     "@wagmi/core": "0.9.5"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ import { ArcanaConnector } from "@arcana/auth-wagmi"
 
 const connector = new ArcanaConnector({
     options: {
-        appId: `${arcana_app_address}`,
+        clientId: `${arcana_client_id}`,
     }
 })
 
@@ -26,7 +26,7 @@ import { ArcanaConnector } from "@arcana/auth-wagmi"
 const connector = new ArcanaConnector({
   chains: [mainnet, optimism, polygon],
   options: {
-    appId: `${arcana_app_address}`,
+    clientId: `${arcana_client_id}`,
   },
 })
 ```
@@ -39,7 +39,7 @@ Options to be passed to Arcana auth SDK.
 const connector = new ArcanaConnector({
   chains: [mainnet, optimism, polygon],
   options: {
-    appId: `${arcana_app_address}`,
+    clientId: `${arcana_client_id}`,
     theme: 'light',            // Defaults to 'dark'
     alwaysVisible: false,      // Defaults to true
     position: 'left'           // Defaults to 'right'

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -13,7 +13,8 @@ import { AuthProvider, EthereumProvider, CHAIN } from "@arcana/auth";
 import { ethers } from "ethers";
 
 type AuthOptions = {
-  appId: ConstructorParameters<typeof AuthProvider>[0];
+  appId?: ConstructorParameters<typeof AuthProvider>[0];
+  clientId?: ConstructorParameters<typeof AuthProvider>[0];
 } & ConstructorParameters<typeof AuthProvider>[1];
 
 export class ArcanaConnector extends Connector {
@@ -25,12 +26,18 @@ export class ArcanaConnector extends Connector {
 
   constructor(config: { chains?: Chain[]; options: AuthOptions }) {
     super(config);
-    this.auth = new AuthProvider(config.options.appId, {
+    let id = config.options?.appId
+      ? config.options?.appId
+      : config.options?.clientId;
+    if (!id) {
+      throw new Error("appAddress or clientId required for arcana auth.");
+    }
+
+    this.auth = new AuthProvider(id, {
       network: config.options.network,
       theme: config.options.theme || "dark",
       chainConfig: {
         chainId: CHAIN.ETHEREUM_MAINNET,
-        rpcUrl: "",
       },
     });
     this.provider = this.auth.provider;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@arcana/auth@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@arcana/auth/-/auth-1.0.0.tgz#b012785c0c637edbf2696b83b65d8aba544c40cf"
-  integrity sha512-mIOJ2hnxdW0aUaNwCoY5rCP+SbO6LD4+JmDsCnKFhQUWf/yBxTH5/p+UijmB5fRZnVtPesx4/A/9125snKFRIg==
+"@arcana/auth@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@arcana/auth/-/auth-1.0.2.tgz#ce03785b9fd2b2ba4d5c8113286c45f78d170ce7"
+  integrity sha512-U+eZunnbMUmTLiJUNJtzicnehm8Lwu9IVIOoRB7NYoYl5ct7/gOWrE21xsMT7VHilJHW0tNZZJxmWHYX8XQPHw==
   dependencies:
     "@metamask/safe-event-emitter" "^2.0.0"
     eth-rpc-errors "^4.0.3"


### PR DESCRIPTION
- Update `@arcana/auth` version to `1.0.2`
- Update usage of `clientId` in docs